### PR TITLE
silk cargoProduct, loadouts, weapons and salvage

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -137,3 +137,13 @@
   cost: 3000
   category: cargoproduct-category-name-materials
   group: market
+
+- type: cargoProduct
+  id: MaterialSilk
+  icon:
+    sprite: Objects/Materials/silk.rsi
+    state: icon
+  product: CrateMaterialSilk
+  cost: 1000
+  category: cargoproduct-category-name-materials
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -157,3 +157,14 @@
     contents:
       - id: IngotSilver
         amount: 3
+
+- type: entity
+  id: CrateMaterialSilk
+  name: silk crate
+  description: 100 pieces of silk.
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: MaterialWebSilk
+        amount: 2

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -140,3 +140,7 @@
       id: LoadoutChiefEngineerUniformSuit
     - type: loadout
       id: LoadoutEngineeringChiefEngineerUniformSkirt
+    - type: loadout
+      id: LoadoutChiefEngineerUniformSuitTurtle
+    - type: loadout
+      id: LoadoutEngineeringChiefEngineerUniformSkirtTurtle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -35,6 +35,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
   - type: AmmoCounter
+  - type: Execution
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -29,6 +29,7 @@
     steps: 5
     zeroVisible: false
   - type: Appearance
+  - type: Execution
   - type: StaticPrice
     price: 500
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -48,6 +48,7 @@
       path: /Audio/Weapons/Guns/MagOut/revolver_magout.ogg
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
+  - type: Execution
   - type: StaticPrice
     price: 500
   - type: MeleeWeapon

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -192,9 +192,6 @@
         - BlueshieldOfficer
     - !type:CharacterAgeRequirement
       min: 21
-    - !type:CharacterSpeciesRequirement
-      species:
-      - Oni
   items:
     - Terminus
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -201,9 +201,6 @@
         - Captain
     - !type:CharacterAgeRequirement
       min: 21
-    - !type:CharacterSpeciesRequirement
-      species:
-      - Oni
   items:
     - Terminus
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -540,3 +540,31 @@
         - ChiefEngineer
   items:
     - ClothingUniformJumpskirtChiefEngineer
+
+- type: loadout
+  id: LoadoutChiefEngineerUniformSuitTurtle
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - ClothingUniformJumpsuitChiefEngineerTurtle
+
+- type: loadout
+  id: LoadoutEngineeringChiefEngineerUniformSkirtTurtle
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - ClothingUniformJumpskirtChiefEngineerTurtle

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -33,6 +33,9 @@
     - proto: MobCarpMagic
       cost: 5
       prob: 0.2
+    - proto: MobShark
+      cost: 5
+      prob: 0.5
     - proto: MobCarpRainbow # carp version of rouny...
       cost: 3
       prob: 0.1

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -124,8 +124,6 @@
           cost: 3
         - proto: PKAUpgradeRange
           cost: 2
-        - proto: CrateSecuritySwat
-          cost: 10
         - proto: ClothingOuterArmorBasic
           cost: 5
         - proto: Claymore

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -124,6 +124,13 @@
           cost: 3
         - proto: PKAUpgradeRange
           cost: 2
+        - proto: CrateSecuritySwat
+          cost: 10
+        - proto: ClothingOuterArmorBasic
+          cost: 5
+        - proto: Claymore
+          cost: 2
+          prob: 0.55
 
 # Mob loot table
 

--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Melee/terminus.yml
@@ -2,12 +2,8 @@
   name: DT-8 "Terminus"
   parent: BaseItem
   id: Terminus
-  description: An advanced weapon crafted specifically for an oni. Capable of firing a spread of disabler shots from its tip.
+  description: An advanced weapon capable of firing a spread of disabler shots from its tip.
   components:
-  - type: RestrictedMelee
-    whitelist:
-      components:
-        - Oni
   - type: Sprite
     sprite: Objects/Weapons/Melee/terminus.rsi
     state: icon


### PR DESCRIPTION
:cl:
- add: Шёлк в продажу карго. Ящик на 100 штук стоит 1000 кредитов.
- add: Водолазки в лоадауты СЕ.
- add: Карпоакулы на экспедиции с карпами.
- add: Ещё немного вещей в лут к экспедициям: Ящик со снаряжением спецназа, обычный бронежилет и клеймор
- add: Возможность казни на большинство огнестрельных орудий.
- remove: Убран вайтлист на выбор в лоадаутах и использование DT-8 "Terminus".
